### PR TITLE
chore: Add post-install items from Ucore

### DIFF
--- a/build_files/01-common.sh
+++ b/build_files/01-common.sh
@@ -94,3 +94,28 @@ DaO51gzKIn1Aumx5L76B64rp7LVWRpnwGPs=
 -----END CERTIFICATE-----
 EOF
 openssl x509 -inform pem -in /etc/pki/akmods/certs/akmods-ublue.pem -out /etc/pki/akmods/certs/akmods-ublue.der
+
+### Configure Updates
+sed -i 's|^ExecStart=.*|ExecStart=/usr/bin/bootc update --quiet|' /usr/lib/systemd/system/bootc-fetch-apply-updates.service
+sed -i 's|^OnUnitInactiveSec=.*|OnUnitInactiveSec=7d\nPersistent=true|' /usr/lib/systemd/system/bootc-fetch-apply-updates.timer
+sed -i 's|#AutomaticUpdatePolicy.*|AutomaticUpdatePolicy=stage|' /etc/rpm-ostreed.conf
+sed -i 's|#LockLayering.*|LockLayering=true|' /etc/rpm-ostreed.conf
+
+### Zram Generator
+cat >/usr/lib/systemd/zram-generator.conf<<'EOF'
+# This config file enables a /dev/zram0 device with the default settings:
+# — size — same as available RAM or 8GB, whichever is less
+# — compression — most likely lzo-rle
+#
+# To disable create empty /etc/systemd/zram-generator.conf file
+[zram0]
+zram-size = min(ram, 8192)
+EOF
+
+### TMPFILES.D
+
+# Create rpm-state
+mkdir -p /var/lib/rpm-state
+cat > /usr/lib/tmpfiles.d/cayo-rpm-state.conf<<'EOF'
+d /var/lib/rpm-state - - - -
+EOF

--- a/build_files/02-docker.sh
+++ b/build_files/02-docker.sh
@@ -20,8 +20,9 @@ echo "net.ipv4.ip_forward = 1" >/usr/lib/sysctl.d/docker-ce.conf
 
 dnf config-manager --set-disabled docker-ce-stable
 
-# Disable the docker service by default
-systemctl disable docker.service
+# Disable the docker socket by default
+sed -i 's/enable docker/disable docker/' /usr/lib/systemd/system-preset/90-default.preset
+systemctl preset docker.service docker.socket
 
 # sysusers.d for docker
 cat >/usr/lib/sysusers.d/docker.conf <<'EOF'

--- a/build_files/12-base-nvidia.sh
+++ b/build_files/12-base-nvidia.sh
@@ -15,3 +15,7 @@ dnf -y install \
 
 dnf config-manager --set-disabled epel-nvidia
 dnf config-manager --set-disabled nvidia-container-toolkit
+
+### Nvidia specific configurations
+semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
+systemctl preset ublue-nvctk-cdi.service

--- a/build_files/20-nas-packages.sh
+++ b/build_files/20-nas-packages.sh
@@ -36,7 +36,7 @@ SOURCE_NAME="$(grep ^NAME= /usr/lib/os-release|cut -f2 -d=|tr -d \")"
 sed -i "s|^PRETTY_NAME=.*|PRETTY_NAME=\"Cayo NAS (Version $IMAGE_VERSION / FROM $SOURCE_NAME $SOURCE_VERSION)\"|" /usr/lib/os-release
 
 # Tmpfiles fix for pcp
-cat > /usr/lib/tmpfiles.d/pcp-cayo.conf<<'EOF'
+cat > /usr/lib/tmpfiles.d/cayo-pcp.conf<<'EOF'
 d /var/lib/pcp/config/pmda 0775 pcp pcp -
 d /var/lib/pcp/config/pmie 0775 pcp pcp -
 d /var/lib/pcp/config/pmlogger 0775 pcp pcp -
@@ -54,4 +54,16 @@ d /var/log/pcp/pmie 0775 pcp pcp -
 d /var/log/pcp/pmlogger 0775 pcp pcp -
 d /var/log/pcp/pmproxy 0775 pcp pcp -
 d /var/log/pcp/sa 0775 pcp pcp -
+EOF
+
+# Tmpfiles fix for duperemove
+cat > /usr/lib/tmpfiles.d/cayo-duperemove.conf<<'EOF'
+d /var/lib/duperemove - - - -
+EOF
+
+# Duperemove configuration
+cat >/etc/default/duperemove<<'EOF'
+HashDir=/var/lib/duperemove
+# Additional options for duperemove binary
+OPTIONS="--skip-zeroes --hash=xxhash"
 EOF


### PR DESCRIPTION
1. Nvidia images install selinux semodule
2. Nviida images enable our ublue-nvctk-cdi service by preset
3. All images disable docker service and socket by preset
4. Modifies Automatic Updates to not auto reboot and only once every 7 days
5. Configures Image Mode
6. Configures rpm-ostreed to stage updates
7. Adds tmpfiles.d for rpm-state and duperemove
8. Add configuration for duperemove
9. Add configuration for zram-generator.conf

Items not done:
1. Removal of disable-ssh-passwords. This file does not exist and it appears password login is enabled by default for users.
2. Localtime workaround for distrobox. This no longer appears necessary for distrobox to function.
3. Firewalld configuration change. The default zone is public which enables cockpit by default. It does not enable mDNS by default which could be useful.
4. Does not create a tmpfiles.d for audit or setroubleshoot. setroubleshoot is not installed and audit properly created its log file.

Closes #16

Signed-off-by: m2 <69128853+m2Giles@users.noreply.github.com>