### PR TITLE
feat: add Kmods SIG kmods for CentOS kernel

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -43,6 +43,14 @@ RUN --mount=type=cache,dst=/var/cache \
     /ctx/11-base-zfs.sh && \
     ostree container commit
 
+RUN --mount=type=cache,dst=/var/cache \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=tmpfs,dst=/var/log \
+    --mount=type=tmpfs,dst=/var/tmp \
+    --mount=type=tmpfs,dst=/tmp \
+    /ctx/12-base-kmods.sh && \
+    ostree container commit
+
 #ifdef NVIDIA
 RUN --mount=type=cache,dst=/var/cache \
     --mount=type=bind,from=ctx,source=/,target=/ctx \

--- a/build_files/12-base-kmods.sh
+++ b/build_files/12-base-kmods.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# enable Kmods SIG repos
+dnf -y install https://mirror.stream.centos.org/SIGs/$(rpm --eval '%{?rhel}/kmods/%{_arch}/repos-main/Packages/c/centos-repos-kmods-%{?rhel}-2.el%{?rhel}.noarch.rpm')
+dnf -y install centos-release-kmods
+dnf config-manager --set-enabled centos-kmods-rebuild
+
+# install desired kmods and utils
+dnf -y install \
+    btrfs-progs \
+    kmod-aacraid \
+    kmod-be2iscsi \
+    kmod-be2net \
+    kmod-btrfs \
+    kmod-hpsa \
+    kmod-lpfc \
+    kmod-megaraid_sas \
+    kmod-mpt3sas \
+    kmod-mptsas \
+    kmod-mptspi \
+    kmod-ntfs3 \
+    kmod-qla2xxx \
+    kmod-vbox-guest-additions
+
+# typically we disable extra repos, but like CRB and EPEL
+# this repo is from CentOS so we leave it enabled


### PR DESCRIPTION
This enables the CentOS Kmods SIG repos and adds kmods and userspace packages which bring the installed kernels features into closer alignment with what we had under Fedora CoreOS.

Namely, this includes drivers for:
- btrfs (plus userspace)
- ntfs3
- vbox-guests
- various network controllers
- various storage controllers

Closes: #24