### PR TITLE
chore: remove duplicate sysusers/tmpfiles libvirt/rpm-state

### DIFF
--- a/build_files/01-common.sh
+++ b/build_files/01-common.sh
@@ -111,11 +111,3 @@ cat >/usr/lib/systemd/zram-generator.conf<<'EOF'
 [zram0]
 zram-size = min(ram, 8192)
 EOF
-
-### TMPFILES.D
-
-# Create rpm-state
-mkdir -p /var/lib/rpm-state
-cat > /usr/lib/tmpfiles.d/cayo-rpm-state.conf<<'EOF'
-d /var/lib/rpm-state - - - -
-EOF

--- a/build_files/30-virt-packages.sh
+++ b/build_files/30-virt-packages.sh
@@ -12,11 +12,6 @@ dnf -y install --setopt=install_weak_deps=False \
     ublue-os-libvirt-workarounds \
     virt-install
 
-### sysusers.d for libvirtdbus
-cat >/usr/lib/sysusers.d/libvirt-dbus.conf <<'EOF'
-u libvirtdbus - 'Libvirt D-Bus bridge' - -
-EOF
-
 dnf -y copr disable ublue-os/packages
 
 # set pretty name for HCI image


### PR DESCRIPTION
ublue-os-libvirt-workarounds now includes the sysusers.d user/group which were needed for libvirt.

In addition, both CentOS and Fedora now provide the rpm-state tmpfile entry in bootc-base-rpmstate.conf so we don't need that either.

Relates: https://github.com/ublue-os/packages/pull/619