### PR TITLE
chore: re-enable mbuffer and sanoid install

### DIFF
--- a/build_files/10-base-packages.sh
+++ b/build_files/10-base-packages.sh
@@ -51,7 +51,6 @@ dnf config-manager --set-disabled tailscale-stable
 
 dnf -y copr enable ublue-os/staging
 dnf -y install snapraid
-# /* dnf -y install sanoid # Currently missing dependencies */
 dnf -y copr disable ublue-os/staging
 
 # /*

--- a/build_files/12-base-zfs.sh
+++ b/build_files/12-base-zfs.sh
@@ -6,10 +6,9 @@ set -xeuo pipefail
 KERNEL_VRA="$(rpm -q "kernel" --queryformat '%{EVR}.%{ARCH}')"
 
 # /*
-### install base server ZFS packages and sanoid dependencies
+### install ZFS packages
 # */
 dnf -y install \
-    pv \
     /tmp/akmods-zfs-rpms/kmods/zfs/kmod-zfs-"${KERNEL_VRA}"-*.rpm \
     /tmp/akmods-zfs-rpms/kmods/zfs/libnvpair3-*.rpm \
     /tmp/akmods-zfs-rpms/kmods/zfs/libuutil3-*.rpm \
@@ -23,3 +22,13 @@ dnf -y install \
 # depmod ran automatically with zfs 2.1 but not with 2.2
 # */
 depmod -a "${KERNEL_VRA}"
+
+# /*
+### install ZFS related packages
+# */
+dnf -y copr enable ublue-os/staging
+dnf -y install \
+    mbuffer \
+    pv \
+    sanoid
+dnf -y copr disable ublue-os/staging


### PR DESCRIPTION
This reorgs to keep ZFS related packages together, and installs both mbuffer and sanoid which were blocked waiting for mbuffer to be added to EPEL 10.

This can be merged once it builds clean.

Relates: #2