### PR TITLE
fix: Fix how the viewable Containerfile is rendered.

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -245,11 +245,11 @@ build-container $image="" $variant="" $flavor="" $version="":
             flags+=("${f#*flag=}")
         fi
     done
-    cpp -E Containerfile.in ${flags[@]} > {{ builddir / '$image_name/Containerfile' }}
+    {{ require('cpp') }} -E -traditional Containerfile.in ${flags[@]} > {{ builddir / '$image_name/Containerfile' }}
     labels="LABEL"
     for l in "${LABELS[@]}"; do
         if [[ "$l" != "--label" ]]; then
-            labels+=" $(jq -R <<< "${l%=*}")=$(jq -R <<< "${l#*=}")"
+            labels+=" $(jq -R <<< "${l%%=*}")=$(jq -R <<< "${l#*=}")"
         fi
     done
     echo "$labels" >> {{ builddir / '$image_name/Containerfile' }}


### PR DESCRIPTION
This makes it so it's possible to run:

`podman build --build-arg IMAGE_VERSION=XXXXXX -f ./build/cayo/Containerfile .` and it actually work.

Signed-off-by: m2 <69128853+m2Giles@users.noreply.github.com>