### PR TITLE
fix: maybe fix zpool import error due to DEFAULT_HOSTNAME

### DIFF
--- a/build_files/13-base-configurations.sh
+++ b/build_files/13-base-configurations.sh
@@ -3,7 +3,7 @@ set -xeuo pipefail
 # /*
 ### OS Release
 # set variant and url for unique identification
-# NOTE: if VARIANT/DEFAULT_HOSTNAME is added to CentOS the echos must become seds
+# NOTE: if VARIANT is added to CentOS the echos must become seds
 # */
 sed -i 's|^Name=.*|Name="Cayo"|' /usr/lib/os-release
 sed -i "s|^Version=.*|Version=\"$IMAGE_VERSION\"|" /usr/lib/os-release
@@ -11,7 +11,6 @@ sed -i 's|^VENDOR_NAME=.*|VENDOR_NAME="Universal Blue"|' /usr/lib/os-release
 sed -i 's|^VENDOR_URL=.*|VENDOR_URL="www.universal-blue.org"|' /usr/lib/os-release
 sed -i 's|^HOME_URL=.*|HOME_URL="https://projectcayo.org"|' /usr/lib/os-release
 sed -i 's|^BUG_REPORT_URL=.*|BUG_REPORT_URL="https://github.com/ublue-os/cayo/issues"|' /usr/lib/os-release
-echo 'DEFAULT_HOSTNAME="cayo"' >>/usr/lib/os-release
 echo 'VARIANT="Cayo"' >>/usr/lib/os-release
 echo 'VARIANT_ID=cayo' >>/usr/lib/os-release
 


### PR DESCRIPTION
We have a DEFAULT_HOSTNAME=cayo in our os-release, but upstream does not ship with this. It seems to be getting included in the initramfs along with ZFS, and some combination of those factors results in a failed service during zpool import which is happening from initramfs.

Fixes: #74