### PR TITLE
fix: remove zfs-dracut to prevent errors

### DIFF
--- a/build_files/12-base-zfs.sh
+++ b/build_files/12-base-zfs.sh
@@ -16,8 +16,7 @@ dnf -y install \
     /tmp/akmods-zfs-rpms/kmods/zfs/libzfs6-*.rpm \
     /tmp/akmods-zfs-rpms/kmods/zfs/libzpool6-*.rpm \
     /tmp/akmods-zfs-rpms/kmods/zfs/python3-pyzfs-*.rpm \
-    /tmp/akmods-zfs-rpms/kmods/zfs/zfs-*.rpm \
-    /tmp/akmods-zfs-rpms/kmods/zfs/other/zfs-dracut-*.rpm
+    /tmp/akmods-zfs-rpms/kmods/zfs/zfs-*.rpm
 
 # /*
 # depmod ran automatically with zfs 2.1 but not with 2.2


### PR DESCRIPTION
zfs-dracut is included with the initramfs rebuild, which includes a default hostname and sets a default hostid from ZFS's perspective, so when this boots on a ZFS system, a zfs service fails during the initramfs boot stage due to the hostname of the booting system not matching the actual system hostname.

There are some ways this could be addressed, but really, we don't need zfs-dracut because root on ZFS is not yet working for bootc installs and we don't have planned support for it at this time.