### PR TITLE
fix: systemd-resolved is now enabled by default

### DIFF
--- a/build_files/13-base-configurations.sh
+++ b/build_files/13-base-configurations.sh
@@ -76,6 +76,17 @@ OPTIONS="--skip-zeroes --hash=xxhash"
 EOF
 
 # /*
+# Ensure systemd-resolved is enabled
+# */
+cat >/usr/lib/systemd/system-preset/91-cayo-resolved.preset <<'EOF'
+enable systemd-resolved.service
+EOF
+systemctl preset systemd-resolved.service
+cat >/usr/lib/tmpfiles.d/cayo-resolved.conf <<'EOF'
+L /etc/resolv.conf - - - - ../run/systemd/resolve/stub-resolv.conf
+EOF
+
+# /*
 ### TMPFILES.D
 # */
 


### PR DESCRIPTION
This ensures that systemd-resolved is preset to be enabled and the /etc/resolv.conf symlink is properly pointed to its stub file.

Fixes: #71