### PR TITLE
feat: add support for Fedora based Cayo

### DIFF
--- a/build_files/01-common.sh
+++ b/build_files/01-common.sh
@@ -17,35 +17,40 @@ rm -rf /opt /usr/local
 ln -sf var/opt /opt
 ln -sf ../var/usrlocal /usr/local
 
-# /*
-# remove subscription manager
-# */
-dnf -y remove \
-  libdnf-plugin-subscription-manager \
-  python3-subscription-manager-rhsm \
-  subscription-manager \
-  subscription-manager-rhsm-certificates
+DIST=$(rpm -E %dist)
+if [[ "${DIST}" == ".el"* ]]; then
+  # /*
+  # remove subscription manager
+  # */
+  dnf -y remove \
+    libdnf-plugin-subscription-manager \
+    python3-subscription-manager-rhsm \
+    subscription-manager \
+    subscription-manager-rhsm-certificates
+
+  # /*
+  # enable CRB, EPEL and other repos
+  # */
+  dnf config-manager --set-enabled crb
+  dnf -y install epel-release
+  dnf -y upgrade epel-release
+else
+  dnf -y install dnf5-plugins
+fi
 
 # /*
 # remove any wifi support from base
 # */
 dnf -y remove \
-    atheros-firmware \
-    brcmfmac-firmware \
-    iwlegacy-firmware \
-    iwlwifi-dvm-firmware \
-    iwlwifi-mvm-firmware \
-    mt7xxx-firmware \
-    nxpwireless-firmware \
-    realtek-firmware \
-    tiwilink-firmware
-
-# /*
-# enable CRB, EPEL and other repos
-# */
-dnf config-manager --set-enabled crb
-dnf -y install epel-release
-dnf -y upgrade epel-release
+  atheros-firmware \
+  brcmfmac-firmware \
+  iwlegacy-firmware \
+  iwlwifi-dvm-firmware \
+  iwlwifi-mvm-firmware \
+  mt7xxx-firmware \
+  nxpwireless-firmware \
+  realtek-firmware \
+  tiwilink-firmware
 
 # /*
 # packages which are more or less what we'd find in CoreOS

--- a/build_files/10-base-packages.sh
+++ b/build_files/10-base-packages.sh
@@ -17,7 +17,12 @@ dnf -y copr disable ublue-os/packages
 # /*
 ### server base packages which are mostly what we added in ucore-minimal
 # */
-dnf config-manager --add-repo https://pkgs.tailscale.com/stable/centos/"$(rpm -E %centos)"/tailscale.repo
+DIST=$(rpm -E %dist)
+if [[ "${DIST}" == ".el"* ]]; then
+  dnf config-manager --add-repo https://pkgs.tailscale.com/stable/centos/"$(rpm -E %centos)"/tailscale.repo
+else
+  dnf config-manager addrepo --from-repofile=https://pkgs.tailscale.com/stable/fedora/tailscale.repo
+fi
 
 dnf -y install --setopt=install_weak_deps=False \
     cockpit-networkmanager \
@@ -42,7 +47,11 @@ dnf -y install --setopt=install_weak_deps=False \
     xdg-dbus-proxy \
     xdg-user-dirs
 
-dnf config-manager --set-disabled tailscale-stable
+if [[ "${DIST}" == ".el"* ]]; then
+  dnf config-manager --set-disabled tailscale-stable
+else
+  dnf config-manager setopt tailscale-stable.enabled=0
+fi
 
 # /* Currently missing dependencies
 # dnf -y copr enable ublue-os/staging
@@ -55,7 +64,7 @@ dnf config-manager --set-disabled tailscale-stable
 ### NOTE: ARM support will require use of proper arch rather than hard coding
 # */
 /run/build_files/github-release-install.sh rclone/rclone "linux-amd64"
-/run/build_files/github-release-install.sh trapexit/mergerfs "el$(rpm -E %centos).$(uname -m)"
+/run/build_files/github-release-install.sh trapexit/mergerfs "fc$(rpm -E %fedora).$(uname -m)"
 
 # /*
 # Cockpit Web Service unit

--- a/build_files/11-base-kernel-swap.sh
+++ b/build_files/11-base-kernel-swap.sh
@@ -16,9 +16,9 @@ popd
 KERNEL_VERSION="$(rpm -q 'kernel' | sed -E 's/kernel-//')"
 
 if [[ "${CACHED_VERSION}" == "$KERNEL_VERSION" ]]; then
-  dnf -y --allowerasing install /tmp/kernel-rpms/kernel-core-"$CACHED_VERSION".rpm
+  dnf -y install --allowerasing /tmp/kernel-rpms/kernel-core-"$CACHED_VERSION".rpm
 else
-  dnf -y --allowerasing install \
+  dnf -y install --allowerasing \
     /tmp/kernel-rpms/kernel-"$CACHED_VERSION".rpm \
     /tmp/kernel-rpms/kernel-core-"$CACHED_VERSION".rpm \
     /tmp/kernel-rpms/kernel-modules-"$CACHED_VERSION".rpm \

--- a/build_files/12-base-kmods.sh
+++ b/build_files/12-base-kmods.sh
@@ -1,5 +1,7 @@
 set -xeuo pipefail
 
+DIST=$(rpm -E %dist)
+if [[ "${DIST}" == ".el"* ]]; then
 # /*
 # enable Kmods SIG repos
 # */
@@ -33,3 +35,4 @@ dnf -y install \
 # typically we disable extra repos, but like CRB and EPEL
 # this repo is from CentOS so we leave it enabled
 # */
+fi

--- a/images.yaml
+++ b/images.yaml
@@ -1,20 +1,18 @@
 ---
 centos-10: &centos-10
   # TODO: Implement a Renovate Regex
-  source: quay.io/centos-bootc/centos-bootc:c10s
+  source: quay.io/centos-bootc/centos-bootc:stream10
   version: 10
-cayo: &cayo
+fedora-42: &fedora-42
+  # TODO: Implement a Renovate Regex
+  source: quay.io/fedora/fedora-bootc:42
+  version: 42
+cayo-base: &cayo-base
   org: ublue-os
   registry: ghcr.io
   repo: cayo
   cppFlags: []
-cayo-base: &cayo-base
-  <<: *cayo
   name: cayo
-cayo-hci: &cayo-hci
-  <<: *cayo
-  name: cayo-hci
-  cppFlags: [ HCI ]
 
 images:
   cayo-base-main-10:
@@ -22,25 +20,11 @@ images:
       - *centos-10
       - *cayo-base
     description: "A bootc server image with ZFS included"
-  cayo-hci-main-10:
-    !!merge <<: 
-      - *centos-10
-      - *cayo-hci
-    description: "A bootc Hyper-Converged Infrastructure image with ZFS included"
-  cayo-base-nvidia-10:
-    !!merge <<: 
-      - *centos-10
+  cayo-base-main-42:
+    !!merge <<:
+      - *fedora-42
       - *cayo-base
-    cppFlags: [ NVIDIA ]
-    description: "A bootc server image with ZFS and NVIDIA included"
-    name: cayo-nvidia
-  cayo-hci-nvidia-10:
-    !!merge <<: 
-      - *centos-10
-      - *cayo-hci
-    cppFlags: [ HCI, NVIDIA ]
-    description: "A bootc Hyper-Converged Infrastructure image with ZFS and NVIDIA included"
-    name: cayo-hci-nvidia
+    description: "A bootc server image with ZFS included"
   rechunker:
     # TODO: Add Renovate Regex configuration
     source: ghcr.io/hhd-dev/rechunk:v1.2.2@sha256:e799d89f9a9965b5b0e89941a9fc6eaab62e9d2d73a0bfb92e6a495be0706907


### PR DESCRIPTION
Recent testing demonstrated that we certainly have users who need support for older x86-64 microarchtectures (CentOS 10 only supports v3 and newer).

We should consider moving Cayo back to Fedora as we don't face this limit there.

ONE of the goals of Cayo was greater stability, but also many process and design improvments. Using Fedora we would retain all our local improvements, but return to some of the "package churn" which has been discussed in other forums.

To address part of the "stability" goal, I'd suggest we investigate shipping a kernel from a "longterm" branch rather than "stable" as Fedora normally does. However, this PR does not address the kernel question.