### PR TITLE
docs: correct incorrect details and provide more info

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -26,15 +26,21 @@ Cayo uses `just` with recipes defined in the `Justfile` to build and test images
 just build cayo
 ```
 Which will build the base Cayo image. Several of the recipes accept parameters. For `just build` the following parameters (in order):
-- "image" (Always Cayo right now)
-- "variant" (base and hci)
-- "flavor" (main and nvidia)
-- "version" (Currently only 10)
+
+- "variant" (centos and fedora)
+- "version" (10 and 42, current centos and fedora versions)
+
 At any time you can pass an empty string `""` to use the default value for that parameter:
 ```bash
-just build "" hci "" 10
+just build fedora 42
 ```
-Which will build a `cayo-hci:10` image.
+This will build a `cayo:42` image from Fedora 42, which is the default of `just build`.
+
+```bash
+just build centos 10
+```
+Which will build a `cayo:10` image from Centos 10.
+
 
 To see what the available recipes are and their parameters just run:
 ```bash
@@ -43,7 +49,7 @@ just
 To get an overview of what's available. Reminder, parameters in `just` are positional and do not have a key/value pair on the commandline.
 
 ## Testing Cayo
-Currently, Cayo does not have an active CI pipeline. This issue is tracked in [#15](https://github.com/ublue-os/cayo/issues/15). Once the workflows are active, images will be built on each PR. However, you can test locally before submitting your PR. There are two primary methods for doing local testing: Container Testing and VM Testing.
+Currently, Cayo's CI pipeline builds images in each PR. However, you can test locally before submitting your PR. There are two primary methods for doing local testing: Container Testing and VM Testing.
 
 ### Container Testing
 Often, the changes we are making do not require a fully running system. In this case, we can use `just run-container` to do a `podman run` of your Container Image. You will be dropped into bash shell inside the Container and will be able to inspect the filesystem. This is useful if you are adding a file, or making some other static change to the Image. When you exit the Container, `podman` will clean it up for you.
@@ -83,4 +89,4 @@ We use `cpp` to preprocess the Containerfile. `podman` and `buildah` both have d
 # My Comment is Here
 # */
 ```
-3. To view a rendered Containerfile, they are located under the `build/$image_name/Containerfile`
+3. To view a rendered Containerfile, they are located under the `build/$variant-$version/Containerfile`

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -39,7 +39,7 @@ This will build a `cayo:42` image from Fedora 42, which is the default of `just 
 ```bash
 just build centos 10
 ```
-Which will build a `cayo:10` image from Centos 10.
+Which will build a `cayo:10` image from CentOS 10.
 
 
 To see what the available recipes are and their parameters just run:

--- a/README.md
+++ b/README.md
@@ -1,61 +1,80 @@
 # Cayo: a Universal Blue server project
 
-Welcome to our work in progress!
+*This project is a work in progress!*
 
-## Overview
+Cayo is a Linux server system intended for container and storage workloads  using included tools like Podman and ZFS. It is suitable to for installation on bare metal or virtual machines, and Cockpit provides easy management. Extensions optionally provide features such as Docker CE, NVIDIA drivers, WiFi support, Samba and Virtual Machine hosting with libvirt. Cayo is a bootc image built on solid the solid foundations of CentOS and Fedora.
 
-This will be a server image similar to [uCore](https://github.com/ublue-os/ucore) but based on CentOS bootc.
+## Quick Summary
+
+This project builds a server image similar to [uCore](https://github.com/ublue-os/ucore) but based on bootc images provided by CentOS and Fedora.
 
 Similarities to uCore:
 
 - bootc/rpm-ostree "immutable" rootfs (CoreOS itself is now built on bootc)
-- three basic offerings will remain: "light-ish", "NAS" and "HCI"(NAS+virt)
-- opinionated, likely including all the same common tools we had in uCore
+- opinionated, includs many of the common tools found in uCore
 - auto-update capabilities
 
 Differences from uCore:
 
 - built on bootc not CoreOS
-- built on EL (Enterprise Linux, eg CentOS) not Fedora
-- installation via [existing bootc install methods](https://docs.fedoraproject.org/en-US/bootc/bare-metal/) rather than coreos-install+butane/ignition
+- built on CentOS with it's default longterm kernel or Fedora with a longterm kernel, both currently are version 6.12
+- installation via [existing bootc install methods](https://docs.fedoraproject.org/en-US/bootc/bare-metal/) or an Anaconda ISO rather than coreos-install with required butane/ignition
+- features will be provided as system extensions (systemd sysext) instead of via various images with tags (eg, minimal, hci and nvidia)
 
 The most noticeable difference for most users will be:
 
-- a slower pace of updates on packages and kernel, owing to the use of an EL base
-- a different way to install
+- new/different ways to install
+- a slower pace of updates for the kernel
+- if using CentOS-based Cayo, system packages will also be updated at a slower pace
 
-## CI/Build Changes
+## New Ideas in CI and Development Processes
 
-As time goes on and our projects have evolved, our build scripts have gotten more powerful, but also more difficult to read.
+As time goes on and Universal Blue projects have evolved, our build scripts have gotten more powerful, but also more difficult to read.
 
-Our hope here is to use this project to experiment with ways of building our images which are easier to follow, both for existing maintainers and any other interested party.
+*A major goal with Cayo is to create new, healthier patterns for building Universal Blue images.* We want tooling which is easy to follow, both for existing maintainers and any other interested party. Enabling local developement and testing is a high priority, and doing this right means our GitHub Actions workflows can be very simple.
 
-The primary goal here: **we want to grok the build process without having to study so many parts**.
+How we are improving our CI and Dev:
 
-How we'll do this:
-
-1. use a YAML file to define the set of images and all key "static" inputs required for a build (some tags and labels are generated or inspected)
+1. use a `images.yaml` file to define the set of images and all key "static" inputs required for a build (some tags and labels are generated or inspected)
 2. use `just` recipies to manage the build related functions, providing same local build commands as used in CI
 3. use Podman's native C preprocssor(CPP) support for flow control not otherwise available in a Containerfile
 4. use devcontainer for a consistent build environment both locally and in CI
 
-
-The YAML uses anchors and aliases. A hint to see the expanded contents:
+`images.yaml` uses anchors and aliases. A hint to see the expanded contents:
 
 > `yq -r "explode(.)|.images" images.yaml`
 
-
-The Justfile is still a bit complicated but reading image information from YAML is cleaner than more complicated bash arrays it previously used.
+The Justfile may still seem a bit complicated but reading image information from YAML is cleaner than the bash arrays previously used in other repos.
 
 The CPP conditional logic in the Containerfile provides several benefits.
+
 - we removed a layer of abstraction, no longer using a single "build.sh" which in turn calls different scripts conditionally based on build-args
 - we need VERY few podman build-args
 - we regain the typical "podman build" behavior of caching each successful layer of an image build, which greatly improves speed of development
 
+*Another goal is to make installing and using Cayo better than its sibling, uCore.*
+
+- choosing which image to install should be simple, only have to choose Cayo based on Fedora or CentOS
+- we will ship only a single image `cayo` rather than three as in uCore (well two, based on CentOS and Fedora)
+  - we will use systemd sysext to provide the features which previously required multiple images
+  - we can ship *fewer packages* in the `cayo` image but have *more features* because of this approach
+  - an example of more features: we'll ship both nvidia-proprietary (support Maxwell/Pascal but not the latest GPUs) plus nvidia-open (support Turing and later GPUs) rather than a single nvidia driver variant in uCore, but enabling this will be less hassle than switching to a completely different image
+  - an example of fewer packages: wifi support (firmwares and other packages) are moving to an extension so that's not wasted space on any machine without wifi
+- we will ship an ISO installer
+  - a common request for uCore was a way to install other than the official CoreOS methods, we can do this with Cayo as we are not tied to the CoreOS paradigms
+  - bootc-image-builder provides easy access to this
+- we will ship qcow2 images, etc
+  - previously we did not have a way to build native uCore VM disk images, bootc-image-builder provides this capability for bootc images like Cayo
+- ZFS is included by default
+  - yes, this change was recently made in uCore as well, but ZFS is a powerful tool core to the Cayo experience
+- system configuration tools will be included
+  - ignition is powerful, but not every wants it, so it's not required
+  - ignition MAY still be used, though!
+  - we also plan to include cloud-init as alternative (pending testing and validation)
+- longterm release kernels (both on CentOS and Fedora) provide  confidence that updates will not render a system unusable due to  kernel regression
 
 ## About the Name
 
 "Cayo" (KYE-oh) comes from "key" or "reef" in Spanish—think a solid foundation and unlocking potential.
 
-Conceptually, the "key" unlocks possibilities, and hints at islands that open up new horizons. "Reef" evokes a resilient, interconnected chain—strong and foundational, like a reef hosting diverse organisms. This fits the idea of a server hosting many services, which Cayo achieves through the stability and strength of an Enterprise Linux base hosting containerized applications.
-
+Conceptually, the "key" unlocks possibilities, and hints at islands that open up new horizons. "Reef" evokes a resilient, interconnected chain—strong and foundational, like a reef hosting diverse organisms. This fits the idea of a server hosting many services, which Cayo achieves through the capabilities and strength of proven technologies like Podman and ZFS, built upon a solid base provided by the CentOS and Fedora projects.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The most noticeable difference for most users will be:
 
 As time goes on and Universal Blue projects have evolved, our build scripts have gotten more powerful, but also more difficult to read.
 
-*A major goal with Cayo is to create new, healthier patterns for building Universal Blue images.* We want tooling which is easy to follow, both for existing maintainers and any other interested party. Enabling local developement and testing is a high priority, and doing this right means our GitHub Actions workflows can be very simple.
+*A major goal with Cayo is to create new, healthier patterns for building Universal Blue images.* We want tooling which is easy to follow, both for existing maintainers and any other interested party. Enabling local development and testing is a high priority, and doing this right means our GitHub Actions workflows can be very simple.
 
 How we are improving our CI and Dev:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project builds a server image similar to [uCore](https://github.com/ublue-o
 Similarities to uCore:
 
 - bootc/rpm-ostree "immutable" rootfs (CoreOS itself is now built on bootc)
-- opinionated, includs many of the common tools found in uCore
+- opinionated, includes many of the common tools found in uCore
 - auto-update capabilities
 
 Differences from uCore:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *This project is a work in progress!*
 
-Cayo is a Linux server system intended for container and storage workloads  using included tools like Podman and ZFS. It is suitable to for installation on bare metal or virtual machines, and Cockpit provides easy management. Extensions optionally provide features such as Docker CE, NVIDIA drivers, WiFi support, Samba and Virtual Machine hosting with libvirt. Cayo is a bootc image built on solid the solid foundations of CentOS and Fedora.
+Cayo is a Linux server system intended for container and storage workloads  using included tools like Podman and ZFS. It is suitable for installation on bare metal or virtual machines, and Cockpit provides easy management. Extensions optionally provide features such as Docker CE, NVIDIA drivers, WiFi support, Samba and Virtual Machine hosting with libvirt. Cayo is a bootc image built on the solid foundations of CentOS and Fedora.
 
 ## Quick Summary
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Similarities to uCore:
 Differences from uCore:
 
 - built on bootc not CoreOS
-- built on CentOS with it's default longterm kernel or Fedora with a longterm kernel, both currently are version 6.12
+- built on CentOS with its default longterm kernel or Fedora with a longterm kernel, both currently are version 6.12
 - installation via [existing bootc install methods](https://docs.fedoraproject.org/en-US/bootc/bare-metal/) or an Anaconda ISO rather than coreos-install with required butane/ignition
 - features will be provided as system extensions (systemd sysext) instead of via various images with tags (eg, minimal, hci and nvidia)
 
@@ -54,7 +54,7 @@ The CPP conditional logic in the Containerfile provides several benefits.
 
 *Another goal is to make installing and using Cayo better than its sibling, uCore.*
 
-- choosing which image to install should be simple, only have to choose Cayo based on Fedora or CentOS
+- choosing which image to install should be simple, only choose if based on Fedora or CentOS
 - we will ship only a single image `cayo` rather than three as in uCore (well two, based on CentOS and Fedora)
   - we will use systemd sysext to provide the features which previously required multiple images
   - we can ship *fewer packages* in the `cayo` image but have *more features* because of this approach


### PR DESCRIPTION
README specifically has more information about the project goals and both docs now correctly reference the use of both CentOS and Fedora.

Closes: #52