### PR TITLE
feat: provide longterm 6.12 kernel for Fedora based Cayo

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -4,7 +4,8 @@ FROM NVIDIA as akmods_nvidia
 FROM ZFS as akmods_zfs
 FROM SOURCE_IMAGE as cayo
 
-ARG IMAGE_VERSION
+ARG IMAGE_VERSION_IN
+ARG KERNEL_NAME_IN
 
 RUN --mount=type=cache,dst=/var/cache \
     --mount=type=tmpfs,dst=/var/log \

--- a/build_files/12-base-zfs.sh
+++ b/build_files/12-base-zfs.sh
@@ -3,7 +3,7 @@ set ${CI:+-x} -euo pipefail
 # /*
 # Get Kernel Version
 # */
-KERNEL_VRA="$(rpm -q "kernel" --queryformat '%{EVR}.%{ARCH}')"
+KERNEL_VRA="$(rpm -q "$KERNEL_NAME" --queryformat '%{EVR}.%{ARCH}')"
 
 # /*
 ### install base server ZFS packages and sanoid dependencies

--- a/build_files/98-cleanup.sh
+++ b/build_files/98-cleanup.sh
@@ -3,7 +3,7 @@ set ${CI:+-x} -euo pipefail
 # /*
 # Ensure Initramfs is generated
 # */
-KERNEL_VERSION="$(rpm -q --queryformat="%{EVR}.%{ARCH}" kernel-core)"
+KERNEL_VERSION="$(rpm -q --queryformat="%{EVR}.%{ARCH}" "$KERNEL_NAME"-core)"
 
 export DRACUT_NO_XATTR=1
 /usr/bin/dracut --no-hostonly --kver "$KERNEL_VERSION" --reproducible --zstd -v --add ostree -f "/lib/modules/$KERNEL_VERSION/initramfs.img"
@@ -13,7 +13,7 @@ chmod 0600 /lib/modules/"$KERNEL_VERSION"/initramfs.img
 # /*
 # Ensure only one kernel/initramfs is present
 # */
-KERNEL_VERSION="$(rpm -q kernel-core --queryformat '%{EVR}.%{ARCH}')"
+KERNEL_VERSION="$(rpm -q "$KERNEL_NAME"-core --queryformat '%{EVR}.%{ARCH}')"
 
 kernel_dirs=("$(ls -1 /usr/lib/modules)")
 if [[ ${#kernel_dirs[@]} -gt 1 ]]; then

--- a/images.yaml
+++ b/images.yaml
@@ -8,7 +8,7 @@ centos-10: &centos-10
 fedora-42: &fedora-42
   # TODO: Implement a Renovate Regex
   source: quay.io/fedora/fedora-bootc:42
-  zfs: ghcr.io/ublue-os/akmods-zfs:coreos-stable-42
+  zfs: ghcr.io/ublue-os/akmods-zfs:longterm-6.12-42
   version: 42
   cppFlags: ["FEDORA"]
 cayo-base: &cayo-base


### PR DESCRIPTION
This adds the LTS kernel to Fedora based Cayo.

Required some modifications since this longterm kernel uses `kernel-longterm` not `kernel` as the package name

Also added the CI env support in podman build.

Closes: #93