### PR TITLE
chore: remove distrobox as a possible extension candidate

### DIFF
--- a/build_files/10-base-packages.sh
+++ b/build_files/10-base-packages.sh
@@ -23,7 +23,6 @@ dnf -y install --setopt=install_weak_deps=False \
     cockpit-selinux \
     cockpit-storaged \
     cockpit-system \
-    distrobox \
     duperemove \
     firewalld \
     hdparm \


### PR DESCRIPTION
Toolbox is the stock tool and distrobox, though preferred by some, is a bit redundant.

I propose we remove it, but consider providing as an extension.