### PR TITLE
feat: add emergency/rescue boot systemd-generator

### DIFF
--- a/container/build_files/01-common.sh
+++ b/container/build_files/01-common.sh
@@ -48,7 +48,7 @@ dnf -y install --setopt=install_weak_deps=False \
 # see detail: https://github.com/ublue-os/main/issues/653
 # */
 CSFG=/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
-curl -sSLo "${CSFG}" https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
+curl -fSL -o "${CSFG}" https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 chmod +x "${CSFG}"
 
 # /*

--- a/container/build_files/01-common.sh
+++ b/container/build_files/01-common.sh
@@ -47,9 +47,9 @@ dnf -y install --setopt=install_weak_deps=False \
 # use CoreOS' generator for emergency/rescue boot
 # see detail: https://github.com/ublue-os/main/issues/653
 # */
-CSFG=/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
-curl -fSL -o "${CSFG}" https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
-chmod +x "${CSFG}"
+COREOS_SULOGIN_GENERATOR_PATH=/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
+curl -fSL -o "${COREOS_SULOGIN_GENERATOR_PATH}" https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
+chmod +x "${COREOS_SULOGIN_GENERATOR_PATH}"
 
 # /*
 # Zram Generator

--- a/container/build_files/01-common.sh
+++ b/container/build_files/01-common.sh
@@ -44,6 +44,14 @@ dnf -y install --setopt=install_weak_deps=False \
   ssh-key-dir
 
 # /*
+# use CoreOS' generator for emergency/rescue boot
+# see detail: https://github.com/ublue-os/main/issues/653
+# */
+CSFG=/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
+curl -sSLo "${CSFG}" https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
+chmod +x "${CSFG}"
+
+# /*
 # Zram Generator
 # */
 cat >/usr/lib/systemd/zram-generator.conf <<'EOF'


### PR DESCRIPTION
This is a feature from CoreOS which allows password-less login during boot with emergency, rescue, single-user modes.

Relates: #108