### PR TITLE
fix: allow non-latest match of kernel in dnf

### DIFF
--- a/container/build_files/centos/12-base-kmods.sh
+++ b/container/build_files/centos/12-base-kmods.sh
@@ -9,8 +9,10 @@ dnf config-manager --set-enabled centos-kmods-rebuild
 
 # /*
 # install desired kmods and utils
+#
+# --nobest allows match for non-latest kernel
 # */
-dnf -y install \
+dnf -y install --nobest \
     btrfs-progs \
     kmod-aacraid \
     kmod-btrfs \


### PR DESCRIPTION
Should fix failure to build cayo:centos when the cached kernel is older than latest available kmods-sig-rebuild kmods. 